### PR TITLE
add cli parameter to specify the root notebook name

### DIFF
--- a/src/converter.py
+++ b/src/converter.py
@@ -36,14 +36,21 @@ class BaseConverter:
         """Prepare the input for further processing. For example extract an archive."""
         return input_
 
-    def convert_multiple(self, files_or_folders: list[Path]) -> list[imf.Notebook]:
+    def convert_multiple(
+        self, files_or_folders: list[Path], root_notebook_name: str | None
+    ) -> list[imf.Notebook]:
         """This is the main conversion function."""
         notebooks = []
         for input_index, file_or_folder in enumerate(files_or_folders):
             now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             index_suffix = "" if len(files_or_folders) == 1 else f" ({input_index})"
+            root_notebook_base_name = (
+                f"{now} - Import from {self.format}"
+                if root_notebook_name is None
+                else root_notebook_name
+            )
             self.root_notebook = imf.Notebook(
-                {"title": f"{now} - Import from {self.format}{index_suffix}"}
+                {"title": f"{root_notebook_base_name}{index_suffix}"}
             )
             # Sanity check - do the input files / folders exist?
             if not file_or_folder.exists():

--- a/src/jimmy.py
+++ b/src/jimmy.py
@@ -52,7 +52,9 @@ def setup_logging(log_to_file: bool, stdout_log_level: str):
     LOGGER.addHandler(console_handler)
 
 
-def convert_all_inputs(inputs: list[Path], format_: str):
+def convert_all_inputs(
+    inputs: list[Path], format_: str, root_notebook_name: str | None
+) -> imf.Notebook:
     """
     Convert the input data to an intermediate representation
     that can be used by the importer later.
@@ -71,7 +73,7 @@ def convert_all_inputs(inputs: list[Path], format_: str):
             raise exc  # this is unexpected -> reraise
     # TODO: Children are added to the parent node / node tree implicitly.
     # This is an anti-pattern, but works for now.
-    parent = converter_.convert_multiple(inputs)
+    parent = converter_.convert_multiple(inputs, root_notebook_name)
     return parent
 
 
@@ -101,7 +103,9 @@ def jimmy(api, config) -> common.Stats:
     inputs_str = " ".join(map(str, config.input))
     LOGGER.info(f'Importing notes from "{inputs_str}"')
     LOGGER.info("Start parsing")
-    root_notebooks = convert_all_inputs(config.input, config.format)
+    root_notebooks = convert_all_inputs(
+        config.input, config.format, config.root_notebook_name
+    )
     stats = common.get_import_stats(root_notebooks)
     LOGGER.info(f"Finished parsing: {stats}")
     if config.print_tree:

--- a/src/jimmy_cli.py
+++ b/src/jimmy_cli.py
@@ -19,9 +19,7 @@ def main():
     )
     # specific formats that need a special handling
     parser.add_argument(
-        "--format",
-        choices=common.get_available_formats(),
-        help="The source format.",
+        "--format", choices=common.get_available_formats(), help="The source format."
     )
     parser.add_argument(
         "--clear-notes", action="store_true", help="Clear everything before importing."
@@ -34,6 +32,7 @@ def main():
         action="store_true",
         help="Print the parsed note tree in intermediate format.",
     )
+    parser.add_argument("--root-notebook-name", help="The name of the root notebook.")
     parser.add_argument(
         "--log-file",
         action="store_true",

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import tempfile
 import unittest
 import zipfile
 
@@ -28,8 +29,8 @@ class Config:
 
 
 def get_stats(inputs, format_):
-    note_tree = jimmy.convert_all_inputs(inputs, format_)
-    return common.get_import_stats(note_tree)
+    note_trees = jimmy.convert_all_inputs(inputs, format_, None)
+    return common.get_import_stats(note_trees)
 
 
 TEST_CASES = []
@@ -83,3 +84,21 @@ class IntermediateFormat(unittest.TestCase):
             testcase.format_,
         )
         self.assertEqual(stats, testcase.expected_output_class)
+
+    def test_root_notebook_name(self):
+        root_notebook_name = "Example name"
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpdirname = Path(tmpdirname)
+            note_trees = jimmy.convert_all_inputs(
+                [tmpdirname], None, root_notebook_name
+            )
+            self.assertEqual(note_trees[0].data["title"], root_notebook_name)
+
+            note_trees = jimmy.convert_all_inputs(
+                [tmpdirname] * 2, None, root_notebook_name
+            )
+            self.assertEqual(len(note_trees), 2)
+            for tree_index, note_tree in enumerate(note_trees):
+                self.assertEqual(
+                    f"{root_notebook_name} ({tree_index})", note_tree.data["title"]
+                )


### PR DESCRIPTION
Not sure if it should be merged. It adds maintenance cost. If the user renames the root notebook manually, it's not a big effort.