### PR TITLE
Don't break on one-line simplenote notes

### DIFF
--- a/src/formats/simplenote.py
+++ b/src/formats/simplenote.py
@@ -22,7 +22,7 @@ class Converter(converter.BaseConverter):
 
         for note_simplenote in input_json["activeNotes"]:
             # title is the first line. In case of title-only notes, create empty second line
-            title, body = title, body = (note_simplenote["content"].split("\r\n", maxsplit=1)+[""])[:2]
+            title, body = common.split_h1_title_from_body(note_simplenote["content"])
 
             note_links = []
             for link in common.get_markdown_links(body):

--- a/src/formats/simplenote.py
+++ b/src/formats/simplenote.py
@@ -21,8 +21,8 @@ class Converter(converter.BaseConverter):
         )
 
         for note_simplenote in input_json["activeNotes"]:
-            # title is the first line
-            title, body = note_simplenote["content"].split("\r\n", maxsplit=1)
+            # title is the first line. In case of title-only notes, create empty second line
+            title, body = title, body = (note_simplenote["content"].split("\r\n", maxsplit=1)+[""])[:2]
 
             note_links = []
             for link in common.get_markdown_links(body):


### PR DESCRIPTION
In case of simplenote notes with just title,  `title, body = (note_simplenote["content"].split("\r\n", maxsplit=1)` will crash because split produces only one item. The change ensures that there are always two items after split