### PR TITLE
Try Nuitka instead of PyInstaller for creating the executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         # "macos-latest" to support ARM based MACs
         # "macos-15-intel" to support Intel based MACs
         # "ubuntu-22.04" to get the lowest possible glibc version for compatibility
-        os: ["windows-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-latest", "macos-15-intel"]
+        os: ["windows-latest", "ubuntu-latest", "ubuntu-latest-arm", "macos-latest", "macos-15-intel"]
         # build "macos-15-intel" executable only at release
         # https://github.com/orgs/community/discussions/26253?sort=top#discussioncomment-3250989
         is_release:
@@ -37,8 +37,8 @@ jobs:
         exclude:
           - is_release: false
             os: "macos-15-intel"
-          - is_release: false
-            os: "ubuntu-latest"
+          #- is_release: false
+          #  os: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -52,20 +52,42 @@ jobs:
           cache: "pip"
           cache-dependency-path: "requirements/requirements*.txt"
       - name: Install dependencies
-        # install only the really required modules before the pyinstaller build
+        # install only the really required modules before the nuitka build
         run: |
           pip install -r requirements/requirements-build.txt
           python download_binaries.py
-      - name: Build executables with pyinstaller
+      - name: Build executables with nuitka
+        shell: bash
         run: |
-          python -m PyInstaller jimmy.spec
+          python -m nuitka --version
+          python -m pip list -v
+          python -m nuitka --list-distribution-metadata
+          python -m nuitka --mode=onefile --assume-yes-for-downloads hello_world.py
+          # --onefile-no-compression to avoid "ValueError: compression parameter 'nb_workers' received an illegal value 4; the valid range is [0, 0]"
+          python -m nuitka \
+            --assume-yes-for-downloads \
+            --mode=onefile \
+            --follow-imports \
+            --follow-import-to=jimmy \
+            $(python generate_nuitka_config.py) \
+            --user-package-configuration-file=nuitka-anyblock_exporter.config.yml \
+            --include-data-dir=./bin=bin \
+            --output-filename="$(python obtain_executable_name.py)" \
+            --output-dir=dist \
+            jimmy/jimmy_cli.py
+      #- name: Build Executable
+      #  uses: Nuitka/Nuitka-Action@main
+      #  with:
+      #    nuitka-version: main
+      #    script-name: jimmy/jimmy_cli.py
+      #    mode: app
       - name: Release
         uses: softprops/action-gh-release@v3
         # release only if there is a release tag
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           files: |
-            ./dist/jimmy*
+            ./dist/jimmy-*
             ./bin/copyright.pandoc
       - name: Check executable size
         shell: bash

--- a/generate_nuitka_config.py
+++ b/generate_nuitka_config.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Generate Nuitka include modules list from jimmy/formats directory."""
+
+from pathlib import Path
+import sys
+
+formats_dir = Path("jimmy/formats")
+format_modules = []
+
+for file in sorted(formats_dir.glob("*.py")):
+    if file.name != "__init__.py":
+        module_name = f"jimmy.formats.{file.stem}"
+        format_modules.append(module_name)
+
+# Generate command-line arguments
+args = ["--include-module=" + module for module in format_modules]
+print(" ".join(args))

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,0 +1,1 @@
+print("hello world")

--- a/nuitka-anyblock_exporter.config.yml
+++ b/nuitka-anyblock_exporter.config.yml
@@ -1,0 +1,4 @@
+- module-name: "anyblock_exporter"
+  data-files:
+    - patterns:
+        - "config.yaml"

--- a/obtain_executable_name.py
+++ b/obtain_executable_name.py
@@ -1,0 +1,23 @@
+import os
+import platform
+
+
+# Generate the executable name based on OS.
+system = platform.system().lower()
+# print("libc:", platform.libc_ver())
+
+# need to correspond to ".github/workflows/build.yml"
+match os.getenv("RUNNER_MACHINE"):
+    case "windows-latest" | "ubuntu-22.04":
+        pass  # default - nothing to do
+    case "ubuntu-latest":
+        # Differentiate between old glibc (above, for maximum compatibility)
+        # and newer glibc (here, just for testing).
+        system += "-new-glibc"
+    case "ubuntu-22.04-arm":
+        system += "-" + platform.machine().lower()
+    case "macos-latest" | "macos-15-intel":
+        # Differentiate between ARM and Intel based Macs.
+        system += "-" + platform.machine().lower()
+executable_name = f"jimmy-{system}"
+print(executable_name)

--- a/requirements/requirements-build.txt
+++ b/requirements/requirements-build.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
-pyinstaller==6.21.0
+Nuitka[app] @ git+https://github.com/Nuitka/Nuitka.git@develop
+ordered-set  # Speeds up compilation significantly
+zstandard    # Reduces final EXE size by 30-50%
 hatch==1.17.0
 twine==6.2.0

--- a/test/smoke-test.bats
+++ b/test/smoke-test.bats
@@ -4,7 +4,7 @@ bats_require_minimum_version 1.5.0
 
 # environment variables
 
-JIMMY_EXE="../dist/jimmy*"
+JIMMY_EXE="../dist/jimmy-*"
 DEFAULT_OUTPUT_FOLDER="$(mktemp -d)/smoke_test_bats_tmp"
 TEST_DATA_DIR=./data/test_data
 REFERENCE_DATA_DIR=./data/reference_data


### PR DESCRIPTION
Last log: https://github.com/marph91/jimmy/actions/runs/27882256949

## Findings

- Executable size almost the same.
- Speed almost the same.
- Build time is longer (15-30 minutes).
- Ubuntu build only successful with latest Ubuntu (24.04). Else `ValueError: compression parameter 'nb_workers' received an illegal value 4; the valid range is [0, 0]`.
- Pandoc is not bundled automatically in Windows (smoke test fails). I didn't dig deeper to find a solution.

## Conclusion

For now, it's not worth to switch to Nuitka. May check again in future.