### PR TITLE
pyinstaller: disable upx to check its impact on size and speed

### DIFF
--- a/jimmy.spec
+++ b/jimmy.spec
@@ -103,7 +103,7 @@ exe = EXE(
     # Strip unneeded libs. Not recommended for windows.
     # https://pyinstaller.org/en/stable/usage.html#cmdoption-s
     strip=platform.system().lower() != "windows",
-    upx=True,
+    upx=False,
     upx_exclude=[],
     runtime_tmpdir=None,
     console=True,


### PR DESCRIPTION
Has no effect:

- Windows: UPX is not installed
- Others: `347 INFO: UPX is available but is disabled on non-Windows due to known compatibility problems.`

Still merge this MR to have UPX disabled explicitly.