### PR TITLE
fix: fix conversion from Telegram saved notes

### DIFF
--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -11,7 +11,10 @@ import jimmy.md_lib.links
 class Converter(converter.BaseConverter):
     @common.catch_all_exceptions()
     def convert_note(self, chat):
-        title = chat["name"]
+        if chat.get("type", "") == "saved_messages":
+            title = "Saved Messages"
+        else:
+            title = chat.get("name", "Unnamed Chat")
         self.logger.debug(f'Converting chat "{title}"')
         note_imf = imf.Note(title, source_application=self.format, original_id=str(chat["id"]))
 


### PR DESCRIPTION
Telegram Chats from Saved Notes conversion fails currently due to it not having any "name" in the `results.json` file.

This PR fixes it.