### PR TITLE
feat: telegram chats conversion with text entities and media handling…

### DIFF
--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -33,6 +33,9 @@ class Converter(converter.BaseConverter):
     inline_thumbnail = True
     use_image_thumbnails = False
 
+    json_fallback_ms : int | None = None
+    file_map: dict[str, Path] | None = None
+
     def _convert_text_entities(self, text_entities: list) -> str:
         """Convert Telegram text_entities (MessageEntity) to Markdown."""
 
@@ -241,7 +244,7 @@ class Converter(converter.BaseConverter):
         )
 
         # 3. Tertiary: filesystem mtime of the associated media file
-        if hasattr(self, "file_map"):
+        if self.file_map is not None:
             for field in self.MESSAGE_MEDIA_TYPES:
                 if field in message and message[field]:
                     media_rel_path = message[field]
@@ -255,7 +258,7 @@ class Converter(converter.BaseConverter):
                     break  # we found a media field; no need to check others
 
         # 4. Quaternary: mtime of the result.json (global fallback)
-        if hasattr(self, "json_fallback_ms") and self.json_fallback_ms:
+        if self.json_fallback_ms is not None:
             return common.timestamp_to_datetime(self.json_fallback_ms / 1000.0)
 
         # 5. Last resort: current time (should rarely happen)
@@ -429,8 +432,8 @@ class Converter(converter.BaseConverter):
             return
 
         # Store file `updated` property as instance variable for later use, if needed
-        self.json_fallback_ms = common.get_ctime_mtime_ms(json_path).get("updated")
-        self.file_map = self._build_file_map(file_or_folder)
+        self.json_fallback_ms : int | None = common.get_ctime_mtime_ms(json_path).get("updated")
+        self.file_map: dict[str, Path] | None = self._build_file_map(file_or_folder)
 
         input_json = json.loads(json_path.read_text(encoding="utf-8"))
 

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -15,6 +15,24 @@ import jimmy.md_lib.links
 
 
 class Converter(converter.BaseConverter):
+    # Telegram Message object `media_types`. Order defines precedence. If multiple media types are
+    # present in a message, the first one encountered will be used as the primary media.
+    MESSAGE_MEDIA_TYPES = [
+        "photo",
+        "video",
+        "voice",
+        "audio",
+        "video_message",
+        "animation",
+        "sticker",
+        "file",
+    ]
+
+    # Configurations for thumbnails, currently not externally configurable
+    include_thumbnails = True
+    inline_thumbnail = True
+    use_image_thumbnails = False
+
     def _convert_text_entities(self, text_entities: list) -> str:
         """Convert Telegram text_entities (MessageEntity) to Markdown."""
 
@@ -25,30 +43,30 @@ class Converter(converter.BaseConverter):
 
         for entity in text_entities:
             text = entity.get("text", "")
-            etype = entity.get("type", "plain")
 
-            # ---- Basic formatting ----
-            if etype == "bold":
-                text = f"**{text}**"
-            elif etype == "italic":
-                text = f"*{text}*"
-            elif etype == "underline":
-                text = f"__{text}__"  # or use <u> if Markdown not supported, but Jimmy handles __
-            elif etype == "strikethrough":
-                text = f"~~{text}~~"
-            elif etype == "code":
-                text = f"`{text}`"
-            elif etype == "pre":
-                # code block – optionally preserve language if provided (not in schema)
-                text = f"\n```\n{text}\n```\n"
+            match entity.get("type", "plain"):
+                # ---- Basic formatting ----
+                case "bold":
+                    text = f"**{text}**"
+                case "italic":
+                    text = f"*{text}*"
+                case "underline":
+                    text = f"__{text}__"
+                case "strikethrough":
+                    text = f"~~{text}~~"
+                case "code":
+                    text = f"`{text}`"
+                case "pre":
+                    # code block – optionally preserve language if provided (not in schema)
+                    text = f"\n```\n{text}\n```\n"
 
-            # ---- Links and mentions ----
-            elif etype == "text_link":
-                url = entity.get("url", "")
-                text = f"[{text}]({url})"
-            elif etype == "text_mention":
-                user_id = entity.get("user_id", "")
-                text = f"[{text}](tg://user?id={user_id})"
+                # ---- Links and mentions ----
+                case "text_link":
+                    url = entity.get("url", "")
+                    text = f"[{text}]({url})"
+                case "text_mention":
+                    user_id = entity.get("user_id", "")
+                    text = f"[{text}](tg://user?id={user_id})"
 
             # ---- Plain or already‐self‑descriptive types ----
             # mention, hashtag, bot_command, url, email, etc. are kept as plain text
@@ -87,21 +105,10 @@ class Converter(converter.BaseConverter):
             - media_markdown: the Markdown string to insert into the note body.
             - resources: list of Resource objects to be written to disk.
         """
-        # Order of precedence – if multiple exist, use the first one
-        media_fields = [
-            "photo",
-            "video",
-            "voice",
-            "audio",
-            "video_message",
-            "animation",
-            "sticker",
-            "file",
-        ]
 
         media_path = None
         media_type = None
-        for field in media_fields:
+        for field in self.MESSAGE_MEDIA_TYPES:
             if field in message and message[field]:
                 media_path = message[field]
                 media_type = field
@@ -196,7 +203,9 @@ class Converter(converter.BaseConverter):
             content = message.get("text", "")
 
         # Handle media
-        media_markdown, media_resources = self._handle_media(message)
+        media_markdown, media_resources = self._handle_media(
+            message, self.include_thumbnails, self.inline_thumbnail, self.use_image_thumbnails
+        )
 
         # Combine text and media (choose your preferred formatting)
         if content and media_markdown:
@@ -212,6 +221,60 @@ class Converter(converter.BaseConverter):
         tags = jimmy.md_lib.tags.get_inline_tags(content, ["#"])
 
         return full_content, media_resources, tags
+
+    def _get_message_datetime(self, message: dict) -> datetime:
+        """Extract Telegram message datetime."""
+
+        # 1. Primary: unixtime (most reliable)
+        if "date_unixtime" in message:
+            return common.timestamp_to_datetime(int(message["date_unixtime"]))
+
+        # 2. Secondary: ISO date string
+        if "date" in message:
+            try:
+                return common.iso_to_datetime(message["date"])
+            except ValueError, TypeError:
+                pass  # fall through
+
+        self.logger.warning(
+            "Neither 'date' nor 'date_unixtime' found, converter might need to be updated."
+        )
+
+        # 3. Tertiary: filesystem mtime of the associated media file
+        if hasattr(self, "file_map"):
+            for field in self.MESSAGE_MEDIA_TYPES:
+                if field in message and message[field]:
+                    media_rel_path = message[field]
+                    media_path = self.file_map.get(media_rel_path)
+
+                    if media_path and media_path.exists():
+                        ts_ms = common.get_ctime_mtime_ms(media_path).get("updated")
+                        if ts_ms:
+                            return common.timestamp_to_datetime(ts_ms / 1000.0)
+
+                    break  # we found a media field; no need to check others
+
+        # 4. Quaternary: mtime of the result.json (global fallback)
+        if hasattr(self, "json_fallback_ms") and self.json_fallback_ms:
+            return common.timestamp_to_datetime(self.json_fallback_ms / 1000.0)
+
+        # 5. Last resort: current time (should rarely happen)
+        self.logger.warning("No timestamp found for message, using current time.")
+        return common.timestamp_to_datetime(common.current_unix_ms() / 1000.0)
+
+    def _build_file_map(self, root_path: Path) -> dict[str, Path]:
+        """Build a file map for quick lookup."""
+
+        file_map = {}
+
+        for file_path in root_path.rglob("*"):
+            if file_path.is_file():
+                rel = file_path.relative_to(root_path)
+                file_map[str(rel)] = file_path
+                # also by filename for loose exports
+                file_map[file_path.name] = file_path
+
+        return file_map
 
     def _build_note_from_messages(
         self,
@@ -240,7 +303,7 @@ class Converter(converter.BaseConverter):
         for _, message in messages:
             content, res, tags = self._process_message(message)
 
-            message_time = common.timestamp_to_datetime(int(message["date_unixtime"]))
+            message_time = self._get_message_datetime(message)
             md_message = jimmy.md_lib.conversations.Message(
                 message.get("from", "Unknown"),
                 content,
@@ -295,7 +358,7 @@ class Converter(converter.BaseConverter):
                 # TODO: handle `service` messages with `action_` at some point
                 continue
 
-            dt = common.timestamp_to_datetime(int(message["date_unixtime"]))
+            dt = self._get_message_datetime(message)
             msg_tuples.append((dt, message))
 
         if not msg_tuples:
@@ -364,6 +427,10 @@ class Converter(converter.BaseConverter):
             self.logger.error(f"result.json not found in {file_or_folder}")
 
             return
+
+        # Store file `updated` property as instance variable for later use, if needed
+        self.json_fallback_ms = common.get_ctime_mtime_ms(json_path).get("updated")
+        self.file_map = self._build_file_map(file_or_folder)
 
         input_json = json.loads(json_path.read_text(encoding="utf-8"))
 

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -16,7 +16,7 @@ import jimmy.md_lib.links
 
 class Converter(converter.BaseConverter):
     def _convert_text_entities(self, text_entities: list) -> str:
-        """Convert Telegram text_entities to Markdown."""
+        """Convert Telegram text_entities (MessageEntity) to Markdown."""
 
         if not text_entities:
             return ""
@@ -141,7 +141,10 @@ class Converter(converter.BaseConverter):
             thumb_resource_path = common.find_file_recursively(self.root_path, thumb_path) or (
                 self.root_path / thumb_path
             )
-            thumb_marker = f"![Thumbnail]({thumb_resource_path})"
+
+            thumb_marker = jimmy.md_lib.links.make_link(
+                "Thumbnail", str(thumb_resource_path), is_image=True
+            )
             thumb_name = f"thumbnail_{Path(thumb_path).name}"
 
             thumb_resource = imf.Resource(
@@ -153,17 +156,16 @@ class Converter(converter.BaseConverter):
             resources.append(thumb_resource)
 
         # 4. Build the main media marker
-        if is_image and not use_thumbnail_for_marker:
-            # Display the image directly
-            main_marker = f"![{file_name}]({resource_path})"
-            main_title = file_name
-        elif use_thumbnail_for_marker:
+        if use_thumbnail_for_marker:
             # Use the thumbnail as a clickable link to the main media
-            main_marker = f"[{thumb_marker}]({resource_path})"
+            main_marker = jimmy.md_lib.links.make_link(
+                str(thumb_marker), str(resource_path), is_image=False
+            )
             main_title = thumb_marker
         else:
-            # Plain file link (no thumbnail inline)
-            main_marker = f"[{file_name}]({resource_path})"
+            main_marker = jimmy.md_lib.links.make_link(
+                file_name, str(resource_path), is_image=is_image
+            )
             main_title = file_name
 
         # 5. Create the main media resource
@@ -189,10 +191,8 @@ class Converter(converter.BaseConverter):
 
         return text if isinstance(text, str) else ""
 
-    def _process_message(
-        self, message: dict, dt: datetime
-    ) -> tuple[str, list[imf.Resource], list[str]]:
-        """Process a single message, returning (body_line, resources, tags)."""
+    def _process_message(self, message: dict) -> tuple[str, list[imf.Resource], list[str]]:
+        """Process a single message, returning (full_content, resources, tags)."""
 
         # Get the rich text if available
         if "text_entities" in message:
@@ -217,11 +217,7 @@ class Converter(converter.BaseConverter):
         # Extract tags from the original text (before media markdown)
         tags = jimmy.md_lib.tags.get_inline_tags(content, ["#"])
 
-        sender = message.get("from", "Unknown")
-        time_str = dt.strftime("%H:%M:%S")
-        body_line = f"{time_str}, **{sender}**: {full_content}"
-
-        return body_line, media_resources, tags
+        return full_content, media_resources, tags
 
     def _build_note_from_messages(
         self,
@@ -243,19 +239,34 @@ class Converter(converter.BaseConverter):
         note.created = first_date
         note.updated = last_date
 
-        body_lines = []
+        md_conversation = jimmy.md_lib.conversations.Conversation()
         resources = []
         all_tags = []
 
-        for dt, message in messages:
-            line, res, tags = self._process_message(message, dt)
-            body_lines.append(line)
+        for _, message in messages:
+            content, res, tags = self._process_message(message)
+
+            message_time = common.timestamp_to_datetime(int(message["date_unixtime"]))
+            md_message = jimmy.md_lib.conversations.Message(
+                message.get("from", "Unknown"),
+                content,
+                prefix=message_time.strftime("%Y-%m-%d %H:%M:%S"),
+            )
+
+            # md_message.attachment_links.extend(resource.original_text for resource in res)
+            md_conversation.messages.append(md_message)
+
             resources.extend(res)
             all_tags.extend(tags)
 
-        note.body = "\n\n".join(body_lines)
+        note.body = md_conversation.to_md()
         note.resources = resources
         note.tags = [imf.Tag(tag) for tag in dict.fromkeys(all_tags)]
+
+        if not note.body and not note.resources and not note.tags:
+            self.logger.debug("Skipping empty chat.")
+
+            return None
 
         frontmatter = {
             "chat_id": chat_id,
@@ -286,6 +297,8 @@ class Converter(converter.BaseConverter):
 
         for message in messages:
             if message.get("type") != "message":
+                # The type is `message` for regular messages and `service` for service messages
+                # TODO: handle `service` messages with `action_` at some point
                 continue
 
             dt = common.timestamp_to_datetime(int(message["date_unixtime"]))
@@ -308,7 +321,7 @@ class Converter(converter.BaseConverter):
         )
 
         # Handle creation time from a service message if needed
-        # (you can add that logic before building or inside)
+        # (logic can add that be added before building or inside)
         if note is not None:
             self.root_notebook.child_notes.append(note)
 

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -358,7 +358,14 @@ class Converter(converter.BaseConverter):
                 self.logger.debug(f"Created note for {day}")
 
     def convert(self, file_or_folder: Path):
-        input_json = json.loads((file_or_folder / "result.json").read_text(encoding="utf-8"))
+        json_path = file_or_folder / "result.json"
+
+        if not json_path.exists():
+            self.logger.error(f"result.json not found in {file_or_folder}")
+
+            return
+
+        input_json = json.loads(json_path.read_text(encoding="utf-8"))
 
         if (chats := input_json.get("chats")) is not None:
             self.logger.debug('Found "chats" key. Assuming that this is a complete "DataExport".')

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -1,5 +1,11 @@
-"""Convert Telegram chats to the intermediate format."""
+"""
+Convert Telegram chats to the intermediate format.
 
+Based on Telegram Data Export Schema: <https://core.telegram.org/import-export>
+"""
+
+from collections import defaultdict
+from datetime import datetime
 import json
 from pathlib import Path
 
@@ -9,54 +15,357 @@ import jimmy.md_lib.links
 
 
 class Converter(converter.BaseConverter):
-    @common.catch_all_exceptions()
-    def convert_note(self, chat):
-        title = chat["name"]
-        self.logger.debug(f'Converting chat "{title}"')
-        note_imf = imf.Note(title, source_application=self.format, original_id=str(chat["id"]))
+    def _convert_text_entities(self, text_entities: list) -> str:
+        """Convert Telegram text_entities to Markdown."""
 
-        md_conversation = jimmy.md_lib.conversations.Conversation()
-        for message in chat["messages"]:
-            if message["type"] != "service" and message.get("action") == "create_group":
-                note_imf.created = common.timestamp_to_datetime(int(message["date_unixtime"]))
-            if message["type"] != "message":
-                continue
+        if not text_entities:
+            return ""
 
-            message_time = common.timestamp_to_datetime(int(message["date_unixtime"]))
-            md_message = jimmy.md_lib.conversations.Message(
-                message["from"],
-                message.get("text", ""),
-                prefix=message_time.strftime("%Y-%m-%d %H:%M:%S"),
+        parts = []
+
+        for entity in text_entities:
+            text = entity.get("text", "")
+            etype = entity.get("type", "plain")
+
+            # ---- Basic formatting ----
+            if etype == "bold":
+                text = f"**{text}**"
+            elif etype == "italic":
+                text = f"*{text}*"
+            elif etype == "underline":
+                text = f"__{text}__"  # or use <u> if Markdown not supported, but Jimmy handles __
+            elif etype == "strikethrough":
+                text = f"~~{text}~~"
+            elif etype == "code":
+                text = f"`{text}`"
+            elif etype == "pre":
+                # code block – optionally preserve language if provided (not in schema)
+                text = f"\n```\n{text}\n```\n"
+
+            # ---- Links and mentions ----
+            elif etype == "text_link":
+                url = entity.get("url", "")
+                text = f"[{text}]({url})"
+            elif etype == "text_mention":
+                user_id = entity.get("user_id", "")
+                text = f"[{text}](tg://user?id={user_id})"
+
+            # ---- Plain or already‐self‑descriptive types ----
+            # mention, hashtag, bot_command, url, email, etc. are kept as plain text
+            # because they are human‑readable markers.
+
+            parts.append(text)
+
+        return "".join(parts)
+
+    def _handle_media(
+        self,
+        message: dict,
+        include_thumbnail: bool = True,
+        inline_thumbnail: bool = True,
+        use_image_thumbnails: bool = False,
+    ) -> tuple[str, list[imf.Resource]]:
+        """
+        Detect media in the message and return (media_markdown, resources).
+
+        Parameters:
+            include_thumbnail (bool):
+                If True, the thumbnail (if present) will be added as a separate
+                Resource object. The file will be copied to the output folder.
+            inline_thumbnail (bool):
+                If True and a thumbnail is used as the link text, the thumbnail
+                Resource will have its `original_text` set so the writer replaces
+                the inline image placeholder. If False, the thumbnail is only
+                attached as a resource without being embedded in the note body.
+            use_image_thumbnails (bool):
+                If True, thumbnails will also be used for image media. Normally,
+                images are displayed directly; with this flag, the thumbnail
+                becomes a clickable link to the full‑size image.
+
+        Returns:
+            (media_markdown, resources)
+            - media_markdown: the Markdown string to insert into the note body.
+            - resources: list of Resource objects to be written to disk.
+        """
+        # Order of precedence – if multiple exist, use the first one
+        media_fields = [
+            "photo",
+            "video",
+            "voice",
+            "audio",
+            "video_message",
+            "animation",
+            "sticker",
+            "file",
+        ]
+
+        media_path = None
+        media_type = None
+        for field in media_fields:
+            if field in message and message[field]:
+                media_path = message[field]
+                media_type = field
+                break
+
+        if not media_path:
+            return "", []
+
+        # ----- Main media -----
+        # Get file name (might not be present for some types)
+        file_name = message.get("file_name", Path(media_path).name)
+
+        # Locate the file (fallback to root_path / media_path)
+        resource_path = common.find_file_recursively(self.root_path, media_path) or (
+            self.root_path / media_path
+        )
+
+        # Determine if it's an image (based on type or extension)
+        is_image = media_type in ["photo", "sticker"] or common.is_image(resource_path)
+        has_thumbnail = "thumbnail" in message and message["thumbnail"]
+
+        resources = []
+
+        # 1. Decide whether to include the thumbnail as a resource
+        include_thumb_resource = (
+            include_thumbnail and has_thumbnail and (not is_image or use_image_thumbnails)
+        )
+
+        # 2. Decide whether to use the thumbnail as the link text in the main marker
+        #    This requires that we want to inline it (so the placeholder will be replaced)
+        use_thumbnail_for_marker = include_thumb_resource and inline_thumbnail
+
+        # 3. Create the thumbnail resource if requested
+        thumb_marker = None
+        if include_thumb_resource:
+            thumb_path = message["thumbnail"]
+            thumb_resource_path = common.find_file_recursively(self.root_path, thumb_path) or (
+                self.root_path / thumb_path
+            )
+            thumb_marker = f"![Thumbnail]({thumb_resource_path})"
+            thumb_name = f"thumbnail_{Path(thumb_path).name}"
+
+            thumb_resource = imf.Resource(
+                filename=thumb_resource_path,
+                original_text=thumb_marker if inline_thumbnail else None,
+                title=thumb_name,
             )
 
-            if (file_ := message.get("file")) is not None:
-                file_md = jimmy.md_lib.links.make_link(
-                    message.get("file_name", ""), str(self.root_path / file_), is_image=True
-                )
-                note_imf.resources.append(
-                    imf.Resource(self.root_path / file_, file_md, message.get("file_name"))
-                )
-                md_message.attachment_links.append(file_md)
+            resources.append(thumb_resource)
 
-            md_conversation.messages.append(md_message)
+        # 4. Build the main media marker
+        if is_image and not use_thumbnail_for_marker:
+            # Display the image directly
+            main_marker = f"![{file_name}]({resource_path})"
+            main_title = file_name
+        elif use_thumbnail_for_marker:
+            # Use the thumbnail as a clickable link to the main media
+            main_marker = f"[{thumb_marker}]({resource_path})"
+            main_title = thumb_marker
+        else:
+            # Plain file link (no thumbnail inline)
+            main_marker = f"[{file_name}]({resource_path})"
+            main_title = file_name
 
-            # update the updated time each message to get the timestamp
-            # of the last message at the end
-            note_imf.updated = message_time
-        note_imf.body = md_conversation.to_md()
+        # 5. Create the main media resource
+        main_resource = imf.Resource(
+            filename=resource_path,
+            original_text=main_marker,
+            title=main_title,
+        )
 
-        if not note_imf.body:
-            self.logger.debug("Skipping empty chat.")
+        # Insert main resource first (so it's processed before the thumbnail)
+        resources.insert(0, main_resource)
+
+        return main_marker, resources
+
+    def _get_message_text(self, message: dict) -> str:
+        """Extract plain text from a Telegram message, handling entity lists."""
+
+        text = message.get("text", "")
+
+        if isinstance(text, list):
+            # text is a list of entities: [{"text": "Hello", "type": "plain"}, ...]
+            return "".join(part.get("text", "") for part in text if isinstance(part, dict))
+
+        return text if isinstance(text, str) else ""
+
+    def _process_message(
+        self, message: dict, dt: datetime
+    ) -> tuple[str, list[imf.Resource], list[str]]:
+        """Process a single message, returning (body_line, resources, tags)."""
+
+        # Get the rich text if available
+        if "text_entities" in message:
+            content = self._convert_text_entities(message["text_entities"])
+        else:
+            # Fallback to plain text (for older exports or simple messages)
+            content = message.get("text", "")
+
+        # Handle media
+        media_markdown, media_resources = self._handle_media(message)
+
+        # Combine text and media (choose your preferred formatting)
+        if content and media_markdown:
+            # media first, text as caption (blockquote)
+            caption = "\n".join(f"> {line}" for line in content.splitlines())
+            full_content = f"{media_markdown}\n\n{caption}"
+        elif media_markdown:
+            full_content = media_markdown
+        else:
+            full_content = content
+
+        # Extract tags from the original text (before media markdown)
+        tags = jimmy.md_lib.tags.get_inline_tags(content, ["#"])
+
+        sender = message.get("from", "Unknown")
+        time_str = dt.strftime("%H:%M:%S")
+        body_line = f"{time_str}, **{sender}**: {full_content}"
+
+        return body_line, media_resources, tags
+
+    def _build_note_from_messages(
+        self,
+        messages: list[tuple[datetime, dict]],
+        title: str,
+        original_id: str,
+        chat_id: int,
+        extra_frontmatter: dict | None = None,
+    ) -> imf.Note | None:
+        """Create a Note from a sorted list of (datetime, message) tuples."""
+
+        if not messages:
+            return None
+
+        first_date = messages[0][0]
+        last_date = messages[-1][0]
+
+        note = imf.Note(title, source_application=self.format, original_id=original_id)
+        note.created = first_date
+        note.updated = last_date
+
+        body_lines = []
+        resources = []
+        all_tags = []
+
+        for dt, message in messages:
+            line, res, tags = self._process_message(message, dt)
+            body_lines.append(line)
+            resources.extend(res)
+            all_tags.extend(tags)
+
+        note.body = "\n\n".join(body_lines)
+        note.resources = resources
+        note.tags = [imf.Tag(tag) for tag in dict.fromkeys(all_tags)]
+
+        frontmatter = {
+            "chat_id": chat_id,
+            "message_count": len(messages),
+            "created": first_date.isoformat(),
+            "updated": last_date.isoformat(),
+        }
+
+        if extra_frontmatter:
+            frontmatter.update(extra_frontmatter)
+
+        note.frontmatter = frontmatter
+
+        return note
+
+    @common.catch_all_exceptions()
+    def convert_note(self, chat):
+        if chat.get("type", "") == "saved_messages":
+            title = "Saved Messages"
+        else:
+            title = chat.get("name", "Unnamed Chat")
+        self.logger.debug(f'Converting chat "{title}"')
+
+        messages = chat.get("messages", [])
+
+        # Filter out non‑message events and create list of (dt, msg)
+        msg_tuples = []
+
+        for message in messages:
+            if message.get("type") != "message":
+                continue
+
+            dt = common.timestamp_to_datetime(int(message["date_unixtime"]))
+            msg_tuples.append((dt, message))
+
+        if not msg_tuples:
+            self.logger.debug(f"No regular messages in chat '{title}', skipping.")
+
             return
 
-        self.root_notebook.child_notes.append(note_imf)
+        # Sort by datetime (should already be in order, but safe)
+        msg_tuples.sort(key=lambda x: x[0])
+
+        note = self._build_note_from_messages(
+            msg_tuples,
+            title=title,
+            original_id=str(chat["id"]),
+            chat_id=chat.get("id"),
+            extra_frontmatter={"chat_type": chat.get("type")},
+        )
+
+        # Handle creation time from a service message if needed
+        # (you can add that logic before building or inside)
+        if note is not None:
+            self.root_notebook.child_notes.append(note)
+
+    def convert_saved_messages_grouped_by_day(self, chat):
+        if chat.get("type") != "saved_messages":
+            self.logger.warning("This method is intended for 'saved_messages' chats only.")
+            self.convert_note(chat)
+
+            return
+
+        messages_by_day = defaultdict(list)
+
+        for message in chat.get("messages", []):
+            if message.get("type") != "message":
+                continue
+
+            dt = common.timestamp_to_datetime(int(message["date_unixtime"]))
+            messages_by_day[dt.date()].append((dt, message))
+
+        if not messages_by_day:
+            self.logger.debug("No regular messages found in saved messages chat.")
+
+            return
+
+        for day, msg_list in messages_by_day.items():
+            msg_list.sort(key=lambda x: x[0])  # already sorted, but ensure
+            title = f"Saved Messages – {day.isoformat()}"
+
+            note = self._build_note_from_messages(
+                msg_list,
+                title=title,
+                original_id=f"{chat['id']}_{day.isoformat()}",
+                chat_id=chat.get("id"),
+                extra_frontmatter={"date": day.isoformat()},
+            )
+
+            if note:
+                self.root_notebook.child_notes.append(note)
+                self.logger.debug(f"Created note for {day}")
 
     def convert(self, file_or_folder: Path):
         input_json = json.loads((file_or_folder / "result.json").read_text(encoding="utf-8"))
+
         if (chats := input_json.get("chats")) is not None:
             self.logger.debug('Found "chats" key. Assuming that this is a complete "DataExport".')
+
             for chat in chats["list"]:
-                self.convert_note(chat)
+                # Dispatch: if it's Saved Messages, group by day; otherwise use normal conversion
+                if chat.get("type") == "saved_messages":
+                    self.convert_saved_messages_grouped_by_day(chat)
+                else:
+                    self.convert_note(chat)
         else:
             self.logger.debug('No "chats" key. Assuming that this is a single "ChatExport".')
-            self.convert_note(input_json)
+
+            # For a single export, check if it's Saved Messages
+            if input_json.get("type") == "saved_messages":
+                self.convert_saved_messages_grouped_by_day(input_json)
+            else:
+                self.convert_note(input_json)

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -119,6 +119,11 @@ class Converter(converter.BaseConverter):
             self.root_path / media_path
         )
 
+        if not resource_path or not resource_path.exists():
+            self.logger.warning(f"Media file not found: {media_path}")
+
+            return "", []
+
         # Determine if it's an image (based on type or extension)
         is_image = media_type in ["photo", "sticker"] or common.is_image(resource_path)
         has_thumbnail = "thumbnail" in message and message["thumbnail"]
@@ -325,6 +330,7 @@ class Converter(converter.BaseConverter):
         if note is not None:
             self.root_notebook.child_notes.append(note)
 
+    @common.catch_all_exceptions()
     def convert_saved_messages_grouped_by_day(self, chat):
         if chat.get("type") != "saved_messages":
             self.logger.warning("This method is intended for 'saved_messages' chats only.")

--- a/src/jimmy/formats/telegram.py
+++ b/src/jimmy/formats/telegram.py
@@ -185,17 +185,6 @@ class Converter(converter.BaseConverter):
 
         return main_marker, resources
 
-    def _get_message_text(self, message: dict) -> str:
-        """Extract plain text from a Telegram message, handling entity lists."""
-
-        text = message.get("text", "")
-
-        if isinstance(text, list):
-            # text is a list of entities: [{"text": "Hello", "type": "plain"}, ...]
-            return "".join(part.get("text", "") for part in text if isinstance(part, dict))
-
-        return text if isinstance(text, str) else ""
-
     def _process_message(self, message: dict) -> tuple[str, list[imf.Resource], list[str]]:
         """Process a single message, returning (full_content, resources, tags)."""
 


### PR DESCRIPTION
…; telegram saved messages grouping by day

- Add support for text entities (bold, italic, underline, strikethrough, code, pre, links, mentions)
- Implement flexible media handling with thumbnail support
- Add grouping of saved messages by day
- Improve frontmatter with chat metadata (chat_id, message_count, dates)
- Add proper resource management for media files

This enhances Telegram export conversion with full Markdown formatting and better media integration (clickable video thumbnails).

This superseed the previous fix PR #97, if this gets approved then that one is not needed anymore.