### PR TITLE
fix: MemoryError safeguard on update_resource_links

### DIFF
--- a/src/jimmy/writer.py
+++ b/src/jimmy/writer.py
@@ -159,6 +159,15 @@ class FilesystemWriter:
         )
         if resource.original_text is None:
             return False
+
+        if resource.original_text == "":
+            # safeguard against empty-string replacement that might cause MemoryError
+            LOGGER.warning(
+                f"Cannot replace empty original text. "
+                f'Resource might have been malformed: "{resource_markdown}".',
+            )
+            return False
+
         # replace existing link
         # Don't use re.subn(), because the link text may contein invalid characters.
         if (replacement_count := note.body.count(resource.original_text)) == 0:


### PR DESCRIPTION
- If by some reason any converter generates the intermediate note format Resource with an empty strings in `original_text`, this update_resource_links might cause a MemoryError due to memory bomb being created by trying to perform empty-string replacement